### PR TITLE
Fix phpstan nullability failures in default branch CI

### DIFF
--- a/src/Csv.php
+++ b/src/Csv.php
@@ -75,22 +75,28 @@ class Csv
 	}
 
 	/**
-	 * @param mixed[][] $liner
+	 * @param array<int|string, mixed> $liner
 	 * @param string[] $keys
 	 */
 	protected static function matchValue(mixed $value, array &$liner, array $keys): void
 	{
-		if (count($keys) > 1) {
-			$tmp = array_shift($keys);
-			if (!isset($liner[$tmp])) {
-				$liner[$tmp] = [];
+		$key = array_shift($keys);
+
+		if ($key === null) {
+			return;
+		}
+
+		if ($keys !== []) {
+			if (!isset($liner[$key]) || !is_array($liner[$key])) {
+				$liner[$key] = [];
 			}
 
-			$liner[$tmp][current($keys)] = [];
-			self::matchValue($value, $liner[$tmp], $keys);
-		} else {
-			$liner[current($keys)] = $value; // @phpstan-ignore-line
+			self::matchValue($value, $liner[$key], $keys);
+
+			return;
 		}
+
+		$liner[$key] = $value;
 	}
 
 }

--- a/src/Values/Email.php
+++ b/src/Values/Email.php
@@ -22,6 +22,10 @@ class Email
 		$parts = Strings::split($value, '~@~');
 		$domain = array_pop($parts);
 
+		if ($domain === null) {
+			throw new InvalidEmailAddressException($value);
+		}
+
 		// Try normalize the domain part
 		if (function_exists('idn_to_ascii')) {
 			$normalizedDomain = idn_to_ascii($domain, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);


### PR DESCRIPTION
## Summary
- Guard `Email` domain extraction before calling `idn_to_ascii()` so phpstan no longer sees a nullable argument/property assignment.
- Simplify `Csv::matchValue()` recursion to avoid offset access on mixed and keep nested assignment type-safe for phpstan.
- Keep behavior unchanged while making the default-branch phpstan workflow pass with current dependency versions.