### PR TITLE
Use php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ tests:
 
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary
- replace `-p phpdbg` with `-p php` in the `coverage` target of `Makefile`
- align this repository with the org-wide coverage migration tracked in #73

## Motivation
- `phpdbg` is being removed from Contributte coverage targets, so this repo should use the regular PHP binary for coverage runs instead

## Changes
- update both `coverage` target variants in `Makefile` to invoke Tester with `-p php`

## Testing
- [x] `make coverage` attempted locally
- [x] `make tests` attempted locally
- [ ] CI passes

Local blockers:
- `make coverage` fails because this environment does not have Xdebug, PCOV, or PHPDBG available for coverage collection when using `php`
- `make tests` fails in `tests/Cases/File.phpt` because the GD extension is not loaded in this environment

Closes #73