### PR TITLE
CI: inherit secrets for coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,5 +12,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.4"


### PR DESCRIPTION
## What changed

- Pass inherited secrets to the reusable coverage workflow.

## Why

The shared coverage workflow can require repository secrets when running from this caller workflow.

## Testing

- Not run (workflow configuration only).